### PR TITLE
Fix Disabled Format options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Update documentation for Event Handling (#80)
 - Add Histograms, Clustering, Regression tutorial (#83)
 
+### Bug fixes
+
+- Fix Disabled Format options #88
+
 ## 3.7.0 (2022-11-16)
 
 ### Features / Enhancements

--- a/src/components/EChartsEditor/EChartsEditor.tsx
+++ b/src/components/EChartsEditor/EChartsEditor.tsx
@@ -57,10 +57,10 @@ export const EChartsEditor: React.FC<Props> = ({ value, onChange, context }) => 
   /**
    * Format Options
    */
-  let monacoOptions = {};
-  if (context.options.editor.format === Format.AUTO) {
-    monacoOptions = { formatOnPaste: true, formatOnType: true };
-  }
+  const monacoOptions =
+    context.options.editor.format === Format.AUTO
+      ? { formatOnPaste: true, formatOnType: true }
+      : { formatOnPaste: false, formatOnType: false };
 
   return (
     <div>

--- a/src/constants/editor.ts
+++ b/src/constants/editor.ts
@@ -20,8 +20,8 @@ export enum Format {
  * Format Options
  */
 export const FormatOptions = [
-  { value: Format.NONE, label: 'Disabled' },
   { value: Format.AUTO, label: 'Auto' },
+  { value: Format.NONE, label: 'Disabled' },
 ];
 
 /**


### PR DESCRIPTION
1. When Format is selected as Disabled, `formatOnParse` and `formatOnType` should be `false`.
2. Switch options in alphabetical order.