### PR TITLE
Clear chart when data is loaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "volkovlabs-echarts-panel",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "volkovlabs-echarts-panel",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.11.2",

--- a/src/components/EChartsPanel/EChartsPanel.tsx
+++ b/src/components/EChartsPanel/EChartsPanel.tsx
@@ -152,6 +152,13 @@ export const EChartsPanel: React.FC<Props> = ({ options, data, width, height, re
     setError(undefined);
 
     /**
+     * Clear chart when data is loaded
+     */
+    if (data.state === LoadingState.Done) {
+      chart.clear();
+    }
+
+    /**
      * Execution Function
      */
     try {


### PR DESCRIPTION
Resolves #207 introduced in v5. One of the changes we made is to replace clear() and the default merge option to not Merge with removed clear() for streaming.

I found this old issue in the Apache EChart: https://github.com/apache/echarts/issues/6202.

I was not able to reproduce the issue to confirm the fix.